### PR TITLE
Fix for in loops

### DIFF
--- a/tempus.js
+++ b/tempus.js
@@ -30,7 +30,11 @@
 
     // The constructor, basically calls `set`
     function Tempus() {
-        if (!(this instanceof Tempus)) return new Tempus(arguments);
+        if (!(this instanceof Tempus)) {
+            t = new Tempus();
+            t.set.apply(t, !(1 in arguments) && /ar/.test(realTypeOf(arguments[0])) ? arguments[0] : arguments);
+            return t;
+        }
         this.set.apply(this, !(1 in arguments) && /ar/.test(realTypeOf(arguments[0])) ? arguments[0] : arguments);
     }
     


### PR DESCRIPTION
Reproduce the problem:
&lt;script src="mootools.js" />
&lt;!--later -->
&lt;script src="tempus.js" />

You will get an error in the console (substr is not a valid function)

That's because mootools modify the Array.prototype exposing functions to for in loops.

here the fix :)

-- edit, forget to escape the HTML
