### PR TITLE
Turn off JSHint white space checking.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -22,6 +22,7 @@
     "loopfunc": true,
 
     "maxlen": 150,
-    "indent": 4
-    
+    "indent": 4,
+    "white": false
+
 }


### PR DESCRIPTION
Turned off white space checking so that lint passed. Alternatively, I could fix the white space issues, but I'm not sure all of those changes would be compatible with your code style. For example, the JSHint white space check requires a space after `function`.

I created an alternative PR with white space checks still active, but the concatenated files pass linting. See the test results in that PR for more details.
