### PR TITLE
Lint fixes, not including concatenated files.

### DIFF
--- a/tempus.interval.js
+++ b/tempus.interval.js
@@ -45,13 +45,13 @@
 
         if (neg) this.swap();
 
-        while(i--) {
+        while (i--) {
             value = this['diff' + intvlMethods[intvlShorthand[i]]]() - overlap;
             overlap = 0;
             if (value) {
                 // Value is negative
                 if (value < 0) {
-                    value = intvlUpperVals[i-1] + value - overlap;
+                    value = intvlUpperVals[i - 1] + value - overlap;
                     overlap = 1;
                 }
                 fragments.unshift(((dateQualifiers[value] || dateQualifiers[0])[i]).replace('%n', value));
@@ -61,7 +61,7 @@
 
         if (neg) this.swap();
 
-        if (fragments[fragments.length-1] == timeSep) fragments.pop();
+        if (fragments[fragments.length - 1] == timeSep) fragments.pop();
 
         return fragments.join(fragSep);
     }
@@ -143,7 +143,7 @@
         };
     }
 
-    for(var meth in intvlMethods) PSetIntvMethod(intvlMethods[meth]);
+    for (var meth in intvlMethods) PSetIntvMethod(intvlMethods[meth]);
     
     /***********************************************/
     /*           ISO8601 Interval Parser           */
@@ -157,7 +157,7 @@
         neg = neg ? 'sub' : 'add';
         
         // Loop through the matches...
-        while(i--) {
+        while (i--) {
             // value is the match (e.g. 3D) minus the last letter (e.g 3)
             matches[i] = matches[i].match(ISOIntervalFragmentRegex);
             
@@ -200,7 +200,7 @@
             if (1 in arguments) this.set.apply(this, ArSlice.call(arguments, 1));
             
             // Our regex to split up the neg/pos, day, and time values.
-            if (!(intveral_string = (''+intveral_string).match(ISOIntervalRegExp))) return false;
+            if (!(intveral_string = ('' + intveral_string).match(ISOIntervalRegExp))) return false;
             
             // Match the date portion:
             if (intveral_string[2] && (matches = intveral_string[2].match(/\d+(?:[,\.]\d+)?[YMWD]/g))) {
@@ -223,7 +223,7 @@
         '%n year', '%n month', '%n day',
         '%n hour', '%n minute', '%n second', '%n millisecond'
     ];
-    for(i = 0; i < qualifiers.length; ++i) pqualifiers[i] = qualifiers[i] + 's';
+    for (i = 0; i < qualifiers.length; ++i) pqualifiers[i] = qualifiers[i] + 's';
     TempusInterval.addLocale('en', [pqualifiers, qualifiers], ['%d ago', 'in %d', 'about %s'], ', ');
     Tempus.Interval = TempusInterval;
 

--- a/tempus.interval.js
+++ b/tempus.interval.js
@@ -170,14 +170,14 @@
             } else {
                 
                 // Set the property using "subValue() or addValue()"
-                this[ neg + intvlMethods[matches[i][3]] ].call(this, +matches[i][1]);
+                this[neg + intvlMethods[matches[i][3]]].call(this, +matches[i][1]);
                 
                 // If we have a decimal, look for the next property in the line
                 if ((+matches[i][2] || 0) > 0) {
                     // Parse the split decimal also:
                     n = arrIndexOf(intvlShorthand, +matches[i][3]) + 1 || intvlShorthand.length;
                     
-                    this[ neg + intvlMethods[ intvlShorthand[n] ] ](+matches[i][1] * intvlUpperVals[n]);
+                    this[neg + intvlMethods[intvlShorthand[n]]](+matches[i][1] * intvlUpperVals[n]);
                 }
             }
         }

--- a/tempus.interval.js
+++ b/tempus.interval.js
@@ -41,29 +41,29 @@
             ,   neg = this.valueOf() < 0
             ,   overlap = 0
             ,   i = intvlCount;
-            fragSep = fragSep || '';
+        fragSep = fragSep || '';
 
-            if (neg) this.swap();
+        if (neg) this.swap();
 
-            while(i--) {
-                value = this['diff' + intvlMethods[intvlShorthand[i]]]() - overlap;
-                overlap = 0;
-                if (value) {
-                    // Value is negative
-                    if (value < 0) {
-                        value = intvlUpperVals[i-1] + value - overlap;
-                        overlap = 1;
-                    }
-                    fragments.unshift(((dateQualifiers[value] || dateQualifiers[0])[i]).replace('%n', value));
+        while(i--) {
+            value = this['diff' + intvlMethods[intvlShorthand[i]]]() - overlap;
+            overlap = 0;
+            if (value) {
+                // Value is negative
+                if (value < 0) {
+                    value = intvlUpperVals[i-1] + value - overlap;
+                    overlap = 1;
                 }
-                if (i == 3 && timeSep) fragments.unshift(timeSep);
+                fragments.unshift(((dateQualifiers[value] || dateQualifiers[0])[i]).replace('%n', value));
             }
+            if (i == 3 && timeSep) fragments.unshift(timeSep);
+        }
 
-            if (neg) this.swap();
+        if (neg) this.swap();
 
-            if (fragments[fragments.length-1] == timeSep) fragments.pop();
+        if (fragments[fragments.length-1] == timeSep) fragments.pop();
 
-            return fragments.join(fragSep);
+        return fragments.join(fragSep);
     }
 
     

--- a/tempus.js
+++ b/tempus.js
@@ -105,10 +105,10 @@
      * @returns {String} One of 'array, regexp, string, number, function, date, object, undefined, null'
      *
      */
-    var realTypeOf = function(v) {
+    var realTypeOf = function (v) {
         // If the var is an undefined or null var the easiest
         // way to get its type is just to coerce it to a string
-        if (v === undef || v === null) return ''+v;
+        if (v === undef || v === null) return '' + v;
         // Otherwise, the easiest way to get its type is to use
         // Object's toString() method, which returns [object <TYPE>] where
         // <TYPE> is the internal name for the object. This is pretty darn reliable!
@@ -169,8 +169,8 @@
      *
      */
     function stringPad(string, width, padString, trailing) {
-        width -= (''+string).length;
-        width = (width > 0 ? (new Array(width+1)).join(padString || 0) : '');
+        width -= ('' + string).length;
+        width = (width > 0 ? (new Array(width + 1)).join(padString || 0) : '');
         return trailing ? string + width : width + string;
     }
 
@@ -207,7 +207,7 @@
         var ob = {
                 test: tester,
                 parse: parser,
-                exp: ArSlice.call(arguments, 2+hasLength),
+                exp: ArSlice.call(arguments, 2 + hasLength),
                 length: (hasLength ? len : arguments.length - 2)
             }
         ,   ex = ob.exp[0];
@@ -257,7 +257,7 @@
                     return this.toString(TIME_FORMATS[a]);
                 };
             }
-            DEFAULT_REVERSE_FORMATTER_REGEX = new RegExp('^'+ DEFAULT_REVERSE_FORMATTER_REGEXS.join('|') + '$');
+            DEFAULT_REVERSE_FORMATTER_REGEX = new RegExp('^' + DEFAULT_REVERSE_FORMATTER_REGEXS.join('|') + '$');
         }
     };
 
@@ -379,20 +379,20 @@
 
         century: function (setter) {
             if (0 in arguments) {
-                return trackDST(this.fullYear(''+(setter-1)+stringPad(this.year(), 2)));
+                return trackDST(this.fullYear('' + (setter - 1) + stringPad(this.year(), 2)));
             }
-            return -~(''+this.fullYear()).substr(0,2);
+            return -~('' + this.fullYear()).substr(0, 2);
         },
 
         isLeapYear: function (year) {
-            return new Date(year || this.fullYear(),1,29).getDate() == 29;
+            return new Date(year || this.fullYear(), 1, 29).getDate() == 29;
         },
 
         // fix getYear because it's broken
         year: function (year) {
-            if (0 in arguments) return trackDST(this.fullYear(+(''+year).substr(0, 2)+2000));
+            if (0 in arguments) return trackDST(this.fullYear(+('' + year).substr(0, 2) + 2000));
 
-            return +(''+this.fullYear()).substr(2);
+            return +('' + this.fullYear()).substr(2);
         },
 
         /*************************************/
@@ -415,7 +415,7 @@
         },
 
         oneIndexedMonth: function (month) {
-            return (0 in arguments) ? this.month(month - 1) : this.month()+1;
+            return (0 in arguments) ? this.month(month - 1) : this.month() + 1;
         },
 
         getMonthName: function (full) {
@@ -516,7 +516,7 @@
             var i = this.month()
             ,   d = Tempus(this);
 
-            while(i--) day += d.month(i + 1).date(-1).date() + 1;
+            while (i--) day += d.month(i + 1).date(-1).date() + 1;
             return day;
         },
 
@@ -539,7 +539,7 @@
         },
 
         eachDayOfYear: function (callback) {
-            return eachDate(this, 1, 365+this.isLeapYear(), 'dayOfYear', 'dayOfYear', callback);
+            return eachDate(this, 1, 365 + this.isLeapYear(), 'dayOfYear', 'dayOfYear', callback);
         },
 
         /*************************************/
@@ -574,13 +574,13 @@
         },
 
         microSeconds: function (setter) {
-            if (0 in arguments) return this.milliseconds(~~(setter/1000));
+            if (0 in arguments) return this.milliseconds(~~(setter / 1000));
 
-            return this.milliseconds()*1000;
+            return this.milliseconds() * 1000;
         },
 
         secondFraction: function (setter) {
-            if (0 in arguments) return this.milliseconds(stringPad((''+setter).substr(0, 3), 3, 0, 1));
+            if (0 in arguments) return this.milliseconds(stringPad(('' + setter).substr(0, 3), 3, 0, 1));
             return this.milliseconds();
         },
 
@@ -644,13 +644,13 @@
             if (realTypeOf(tz) == TYPE_NUMBER) return this.timezoneOffset(tz);
             if (0 in arguments) {
                 if (/^[zZ0]|GMT$/.test(tz)) return this.timezoneOffset(0);
-                tz = (''+tz).match(/^(.)(\d{2}).?(\d{2})$/);
+                tz = ('' + tz).match(/^(.)(\d{2}).?(\d{2})$/);
                 var tzi = ~~(+(tz[2]) * 60) + ~~(+tz[3]);
                 return this.timezoneOffset(tz[1] === '-' ? tzi : -tzi);
             }
             tz = this._tz;
-            if(tz < 0) tz = -tz;
-            return (this._tz < 0 ? '-' : '+') + (stringPad(~~(tz/60),2)) + (stringPad(~~(tz%60),2));
+            if (tz < 0) tz = -tz;
+            return (this._tz < 0 ? '-' : '+') + (stringPad(~~(tz / 60), 2)) + (stringPad(~~(tz % 60), 2));
         },
 
         ISOTimezone: function (setter) {
@@ -726,7 +726,7 @@
                 this.timezoneOffset(this._oldTz);
                 this._tzisl = track;
                 delete this._oldTz;
-            } else if(!('_oldTz' in this) && force !== false) {
+            } else if (!('_oldTz' in this) && force !== false) {
                 track = this._tzisl;
                 this._oldTz = this.timezoneOffset();
                 this.timezone(0);
@@ -821,7 +821,7 @@
 
         // If `set<(UTC)Method>` does not exist, then create it. We want to check,
         // because we may have already created it in TProto to work to a specific usecase
-        if(!TProto['set' + properMethodName]) {
+        if (!TProto['set' + properMethodName]) {
 
             // If the method is a UTC method, it will always have a non-UTC
             // version available, so we can just use that, but reset the tz
@@ -1045,7 +1045,7 @@
         // The test function
         function (a, b) {
             // If the second arg (formats) is array of formats, use the first one.
-            b = realTypeOf(b) == TYPE_ARRAY && 0 in b? b[0] : b;
+            b = realTypeOf(b) == TYPE_ARRAY && 0 in b ? b[0] : b;
 
             // lastIndex needs to be reset for some browsers, i.e Safari. Issue #11
             strftimeRegExp.lastIndex = 0;
@@ -1066,8 +1066,8 @@
             format = format == undef ? DEFAULT_REVERSE_FORMATTER : format;
 
             if (realTypeOf(format) == TYPE_ARRAY) {
-                for(i = 0; i in format; i++)
-                    try { return this.set(string, format[i]); } catch(e){}
+                for (i = 0; i in format; i++)
+                    try { return this.set(string, format[i]); } catch (e) {}
                 throw new Error("Cannot parse '" + string + "' with '" + format + "'");
             }
 
@@ -1080,12 +1080,12 @@
                 throw new Error("Cannot parse '" + string + "' with '" + format + "'");
 
             i = match.length;
-            while(i--) {
+            while (i--) {
                 // Date should be set after month, that way it doesn't end up jumping to the next month
-                if (formatFunction[i-1] === TProto.date && (days = match[i])) continue;
+                if (formatFunction[i - 1] === TProto.date && (days = match[i])) continue;
 
-                if (realTypeOf(formatFunction[i-1]) == TYPE_FUNCTION) {
-                    formatFunction[i-1].call(this, match[i]);
+                if (realTypeOf(formatFunction[i - 1]) == TYPE_FUNCTION) {
+                    formatFunction[i - 1].call(this, match[i]);
                 }
             }
             this.date(days);

--- a/tempus.js
+++ b/tempus.js
@@ -125,8 +125,8 @@
         // about the only reliable way to test for argument objects that don't declare their
         // internal class
         realTypeOf = function (v) {
-           if (v && v.hasOwnProperty && v.hasOwnProperty('callee')) return 'arguments';
-           return _realTypeOf(v);
+            if (v && v.hasOwnProperty && v.hasOwnProperty('callee')) return 'arguments';
+            return _realTypeOf(v);
         };
     }
 
@@ -773,7 +773,8 @@
         'minutes',
         'seconds', 'milliseconds', 'microSeconds', 'secondFraction',
         'time', 'timezone', 'timezoneOffset', 'ISOTimezone', 'timeStamp', 'AMPM', 'ampm', 'century',
-        'locale'];
+        'locale'
+    ];
 
     function PDateSetMethod(methodName, isUTC) {
         var properMethodName = methodName;

--- a/tempus.js
+++ b/tempus.js
@@ -170,7 +170,7 @@
      */
     function stringPad(string, width, padString, trailing) {
         width -= (''+string).length;
-        width = (width > 0 ? ( new Array(width+1) ).join( padString || 0 ) : '');
+        width = (width > 0 ? (new Array(width+1)).join(padString || 0) : '');
         return trailing ? string + width : width + string;
     }
 


### PR DESCRIPTION
Lint fixes for tempus.js and tempus.interval.js. The concatenated files still do not pass linting. This is an alternative to setting `white:false` in the .jshintrc.

There's an unmatched brace at the end of tempus.with.interval.js, which causes that file to fail the lint:concatenated check, among other issues.

```
Running "lint:concatenated" (lint) task
Linting tempus.with.interval.js...ERROR
[L1369:C5] Expected 'if' to have an indentation at 1 instead at 5.
    if (typeof module != 'undefined' && module.exports) {
[L1370:C9] Expected 'module' to have an indentation at 5 instead at 9.
        module.exports = Tempus;
[L1372:C5] Expected '}' to have an indentation at 1 instead at 5.
    } else if (typeof define == "function" && define.amd) {
[L1373:C9] Expected 'define' to have an indentation at 5 instead at 9.
        define('Tempus', [], function () { return Tempus; });
[L1375:C5] Expected '}' to have an indentation at 1 instead at 5.
    } else {
[L1376:C9] Expected 'global' to have an indentation at 5 instead at 9.
        global.Tempus = Tempus;
[L1377:C5] Expected '}' to have an indentation at 1 instead at 5.
    }
[L1379:C1] Expected '(end)' and instead saw '}'.
}(this, Date, [].slice));
[L1376:C9] 'global' is not defined.
        global.Tempus = Tempus;

<WARN> Task "lint:concatenated" failed. Use --force to continue. </WARN>

Aborted due to warnings.
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```
